### PR TITLE
feat(azurecert): Auto-detect Azure AD endpoint from SharePoint URL

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,48 @@
+# feat(azurecert): Auto-detect Azure AD endpoint from SharePoint URL
+
+## Summary
+
+Auto-detects the correct Azure AD endpoint for sovereign clouds based on the SharePoint site URL domain suffix. No configuration changes required.
+
+## How it works
+
+The `GetAuth()` function now automatically selects the correct Azure AD endpoint:
+
+| SharePoint Domain | Azure AD Endpoint |
+|-------------------|-------------------|
+| `*.sharepoint.com` | `login.microsoftonline.com` (Commercial) |
+| `*.sharepoint.us` | `login.microsoftonline.us` (GCC High) |
+| `*.sharepoint.cn` | `login.chinacloudapi.cn` (China) |
+| `*.sharepoint.de` | `login.microsoftonline.de` (Germany) |
+
+## Usage
+
+No changes to configuration required. Just use the SharePoint site URL:
+
+**Commercial:**
+```json
+{
+  "siteUrl": "https://contoso.sharepoint.com/sites/test",
+  "tenantId": "...",
+  "clientId": "...",
+  "certPath": "cert.pfx",
+  "certPass": "password"
+}
+```
+
+**GCC High:**
+```json
+{
+  "siteUrl": "https://contoso.sharepoint.us/sites/test",
+  "tenantId": "...",
+  "clientId": "...",
+  "certPath": "cert.pfx",
+  "certPass": "password"
+}
+```
+
+## Backwards Compatible
+
+- Commercial cloud (`.sharepoint.com`) continues to work exactly as before
+- No breaking changes to existing configurations
+- Uses Azure SDK's built-in cloud environment constants

--- a/strategies/azurecert/azurecert.go
+++ b/strategies/azurecert/azurecert.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/koltyakov/gosip"
 	"github.com/koltyakov/gosip/cpass"
@@ -39,6 +40,11 @@ var (
 	"certPass": "password"
 }
 */
+// Azure AD endpoint is auto-detected from SiteURL:
+//   - *.sharepoint.com  -> login.microsoftonline.com (Commercial)
+//   - *.sharepoint.us   -> login.microsoftonline.us (GCC High)
+//   - *.sharepoint.cn   -> login.chinacloudapi.cn (China)
+//   - *.sharepoint.de   -> login.microsoftonline.de (Germany)
 type AuthCnfg struct {
 	SiteURL  string `json:"siteUrl"`  // SPSite or SPWeb URL, which is the context target for the API calls
 	TenantID string `json:"tenantId"` // Azure Tenant ID
@@ -107,6 +113,9 @@ func (c *AuthCnfg) GetAuth() (string, int64, error) {
 		config := auth.NewClientCertificateConfig(c.CertPath, c.CertPass, c.ClientID, c.TenantID)
 		config.Resource = resource
 
+		// Auto-detect Azure AD endpoint from SharePoint URL
+		config.AADEndpoint = getAADEndpoint(u.Host)
+
 		authorizer, err := config.Authorizer()
 		if err != nil {
 			return "", 0, err
@@ -114,13 +123,21 @@ func (c *AuthCnfg) GetAuth() (string, int64, error) {
 		c.authorizer = authorizer
 	}
 
-	// token, err := config.ServicePrincipalToken()
-	// if err != nil {
-	// 	return "", 0, err
-	// }
-	// return token.Token().AccessToken, token.Token().Expires().Unix(), nil
-
 	return c.getToken()
+}
+
+// getAADEndpoint returns the Azure AD endpoint based on SharePoint domain
+func getAADEndpoint(host string) string {
+	switch {
+	case strings.HasSuffix(host, ".sharepoint.us"):
+		return azure.USGovernmentCloud.ActiveDirectoryEndpoint
+	case strings.HasSuffix(host, ".sharepoint.cn"):
+		return azure.ChinaCloud.ActiveDirectoryEndpoint
+	case strings.HasSuffix(host, ".sharepoint.de"):
+		return azure.GermanCloud.ActiveDirectoryEndpoint
+	default:
+		return azure.PublicCloud.ActiveDirectoryEndpoint
+	}
 }
 
 // GetSiteURL gets SharePoint siteURL


### PR DESCRIPTION
## Summary

Auto-detects the correct Azure AD endpoint for sovereign clouds based on the SharePoint site URL domain suffix. No configuration changes required.

## How it works

The `GetAuth()` function now automatically selects the correct Azure AD endpoint:

| SharePoint Domain | Azure AD Endpoint |
|-------------------|-------------------|
| `*.sharepoint.com` | `login.microsoftonline.com` (Commercial) |
| `*.sharepoint.us` | `login.microsoftonline.us` (GCC High) |
| `*.sharepoint.cn` | `login.chinacloudapi.cn` (China) |
| `*.sharepoint.de` | `login.microsoftonline.de` (Germany) |

## Usage

No changes to configuration required. Just use the SharePoint site URL:

**Commercial:**
```json
{
  "siteUrl": "https://contoso.sharepoint.com/sites/test",
  "tenantId": "...",
  "clientId": "...",
  "certPath": "cert.pfx",
  "certPass": "password"
}
```

**GCC High:**
```json
{
  "siteUrl": "https://contoso.sharepoint.us/sites/test",
  "tenantId": "...",
  "clientId": "...",
  "certPath": "cert.pfx",
  "certPass": "password"
}
```

## Backwards Compatible

- Commercial cloud (`.sharepoint.com`) continues to work exactly as before
- No breaking changes to existing configurations
- Uses Azure SDK's built-in cloud environment constants